### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [10/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -72,6 +72,9 @@
   "deployment": {
     "glance": {
       "crowbar-revision": 0,
+      "element_states": {
+        "glance-server": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "glance-server" ]

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -117,6 +117,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-glance.json   |    3 +++
 chef/data_bags/crowbar/bc-template-glance.schema |   10 ++++++++++
 2 files changed, 13 insertions(+), 0 deletions(-)
