### PR TITLE
Misc bug fixes - glance & swift [1/3]

### DIFF
--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -85,6 +85,8 @@ class GlanceService < ServiceObject
       base["attributes"]["glance"]["use_keystone"] = false
     end
     base["attributes"]["glance"]["service_password"] = '%012d' % rand(1e12)
+    base["attributes"]["glance"]["api"]["bind_open_address"] = true
+    base["attributes"]["glance"]["registry"]["bind_open_address"] = true
 
     @logger.debug("Glance create_proposal: exiting")
     base


### PR DESCRIPTION
swift:
- don't try to use swauth if no keystone present. no longer supporting swauth
- make the proxy cert last for a bit (default expiration was +1 month. now +1 year)
  glance:
- make API and Registry listne to all addresses by default, so CLI tools work
  
  crowbar_framework/app/models/glance_service.rb |    2 ++
  1 files changed, 2 insertions(+), 0 deletions(-)
