### PR TITLE
Don't add any images yet

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -4,7 +4,6 @@
   "attributes": {
     "glance": {
       "images": [
-        "http://|ADMINWEB|/files/ami/ubuntu-11.04-server-cloudimg-amd64.tar.gz"
       ],
       "api": {
         "verbose": true,


### PR DESCRIPTION
We thought this made the code too dependent on the exact image that's going to be uploaded, but I'm uncertain if this change is desirable upstream or not.
