### PR TITLE
Rewrite network barclamp to manage interfaces directly. [15/22]

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -17,7 +17,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_address = keystone.address.addr
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_service_port = keystone["keystone"]["api"]["service_port"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
@@ -70,8 +70,8 @@ bash "Sync api glance db" do
 end
 
 if node[:glance][:use_keystone]
-  my_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  my_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+  my_admin_ip = node.address.addr
+  my_public_ip = node.address("public").addr
   api_port = node["glance"]["api"]["bind_port"]
 
   keystone_register "glance api wakeup keystone" do

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -33,7 +33,7 @@ package "glance" do
 end
 
 # Make sure we use the admin node for now.
-my_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+my_ipaddress = node.address.addr
 node[:glance][:api][:bind_host] = my_ipaddress
 node[:glance][:registry][:bind_host] = my_ipaddress
 
@@ -61,7 +61,7 @@ if node[:glance][:database] == "mysql"
     mysql = node
   end
 
-  mysql_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(mysql, "admin").address if mysql_address.nil?
+  mysql_address = mysql.address.addr
   Chef::Log.info("Mysql server found at #{mysql_address}")
 
   # Create the Glance Database

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -16,7 +16,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_address = keystone.address.addr
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
   keystone_service_port = keystone["keystone"]["api"]["service_port"]
@@ -65,8 +65,8 @@ bash "Sync registry glance db" do
 end
 
 if node[:glance][:use_keystone]
-  my_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  my_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+  my_admin_ip = node.address.addr
+  my_public_ip = node.address("public").addr
   api_port = node["glance"]["api"]["bind_port"]
 
   keystone_register "glance registry wakeup keystone" do

--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -28,7 +28,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_address = keystone.address.addr
   keystone_token = keystone["keystone"]["service"]["token"]
   Chef::Log.info("Keystone server found at #{keystone_address}")
 else

--- a/chef/cookbooks/glance/recipes/setup.rb
+++ b/chef/cookbooks/glance/recipes/setup.rb
@@ -19,7 +19,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  key_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address
+  key_ip = keystone.address.addr
   admin_token = "-I #{keystone["keystone"]["admin"]["username"]}"
   admin_token = "#{admin_token} -K #{keystone["keystone"]["admin"]["password"]}"
   admin_token = "#{admin_token} -T #{keystone["keystone"]["admin"]["tenant"]}"
@@ -28,7 +28,7 @@ else
   admin_token = ""
 end
 
-my_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+my_ipaddress = node.address.addr
 port = node["glance"]["api"]["bind_port"]
 
 glance_args = "-H #{my_ipaddress} -p #{port} #{admin_token}"


### PR DESCRIPTION
Making the distro tools handle reconfiguring network interfaces for us
was needlessly fragile, since we were rewriting the network config and
changing the state of the interfaces while we were in the middle of
converging the node -- if we happened to do anything that would try to
talk to the chef-server while any of the interfaces needed to talk to
the admin network was changing, we could easily wind up in a state
where manual intervention would be needed to recover.

Additionally, the network barclamp had to have a good deal of
special-casing to handle all the distro-specific caveats that went
along with using ifup/ifdown directly to manage the nics.

This code does away with all that by teaching the network barclamp how
to manage our interfaces directly, reducing the distro-specific code
to what is needed to write out the proper configuation for ifup/ifdown
on the operating system.

New features:
- All interface manipulation happens early in the compile phase of
  the chef-client runs, and the recipe will pause for up to 60
  seconds to verify that it can ping the node with the provisioner
  role (if one is assigned).  This should ensure that the chef-client
  run succeeds with minimal delay even when we are forced to do
  something that may trigger a spanning tree update on the
  network. This frees the rest of the barclamps from having to care
  about sleeping due to network configuration changes.
- The network barclamp posts its state on
  node[:crowbar_wall][:network] to allow other barclamps to easily
  see what interfaces are members of what network and what IP
  addresses are assigned to the node.
- Switching between single, dual, and team mode is more or less
  seamless now. You can easily switch network modes even when nova VMs are
  up and running without dropping more than a packet or two. The sole
  exception I have seen is Nova running in tenant_vlan mode.
- It is trivial to deploy with a configuration that does not use vlan
  tagging at all.  The network barclamp will manage our interfaces
  correctly by assigning multiple IP addresses to the appropriate
  interfaces for each network, and it will handle moving addresses
  and routes around as needed.  Debian and Redhat config file
  generation has been updated to handle binding multiple IP addresses
  to interfaces so that a rebooted node will come up with the proper
  configuration before chef-client runs.
- Helper classes have been added to the barclamp recipe that model IP
  addresses (including IP address ranges) and network interfaces.
  Those helpers also inject convienenece routines into the CHef::Node
  class to make it easier to find interfaces and addresses for each
  of our networks.
