### PR TITLE
re-factor out intialize method in controllers [9/22]

### DIFF
--- a/crowbar_framework/app/controllers/glance_controller.rb
+++ b/crowbar_framework/app/controllers/glance_controller.rb
@@ -14,8 +14,13 @@
 # 
 
 class GlanceController < BarclampController
-  def initialize
-    @service_object = GlanceService.new logger
+  before_filter :set_service_object
+ 
+  def set_service_object
+     @service_object = GlanceService.new logger
   end
+
+  private :set_service_object
+  
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/glance_controller.rb           |   47 +++++++++++---------
 1 files changed, 26 insertions(+), 21 deletions(-)
