### PR TITLE
Make locking more debuggable, and start reworking smoketests. [4/6]

### DIFF
--- a/smoketest/00-check-images.test
+++ b/smoketest/00-check-images.test
@@ -1,24 +1,6 @@
 #!/bin/bash
 
-declare -A keystone_res glance_res
-. <(parse_yml_or_json "$LOGDIR/keystone-deployed.json" keystone_res)
-. <(parse_yml_or_json "$LOGDIR/glance-deployed.json" glance_res)
-glance_port=${glance_res['attributes.glance.api.bind_port']}
-glance_nodes=$(knife_node_find 'roles:glance-server' FQDN)
-keystone_nodes=$(knife_node_find 'roles:keystone-server' FQDN)
-keystone_user=${keystone_res['attributes.keystone.admin.username']}
-keystone_tenant=${keystone_res['attributes.keystone.admin.tenant']}
-keystone_password=${keystone_res['attributes.keystone.admin.password']}
-keystone_port=${keystone_res['attributes.keystone.api.api_port']}
-
-keystone_ip=$(name_to_ip $keystone_nodes)  # Assuming there is only one Keystone
-
-for node in $glance_nodes; do
-    if run_on $node glance -H $(name_to_ip $node) -p "$glance_port" -I $keystone_user -K $keystone_password \
-        -T $keystone_tenant -N http://$keystone_ip:$keystone_port/v2.0 details |grep -q 'Status: active'; then
-       echo "Glance running on $node"
-    else
-       echo "Glance not running on $node!"
-       exit 1
-    fi
-done
+apt-get install python-glanceclient
+. .openrc
+keystone endpoint-list |grep glance || \
+    die "Cannot find endpoint for glance in Keystone."


### PR DESCRIPTION
- Replace acquire_lock and release_lock with a single try_lock function.
- Convert all users of acquire_lock and release_lock to use try_lock.
- Add instrumentation to try_lock to blow up informativey on deadlock.
- Chop out parts of openstack smoketests that are not applicable.
  
  smoketest/00-check-images.test |   26 ++++----------------------
  1 file changed, 4 insertions(+), 22 deletions(-)

Crowbar-Pull-ID: 0007483fe1414a718d9d6de4c89b95020d7b4f05

Crowbar-Release: development
