### PR TITLE
Unit test additions and clean-up to enable the mysql barclamp to be applied [3/4]

### DIFF
--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -34,10 +34,10 @@ class GlanceService < ServiceObject
     nodes = Node.all
     nodes.delete_if { |n| n.nil? or n.is_admin? }
     if nodes.size >= 1
-      add_role_to_instance_and_node(n[0].name, base.name, "glance-server")
+      add_role_to_instance_and_node(nodes[0].name, base.name, "glance-server")
     end
 
-    hash = base.config_hash
+    hash = base.current_config.config_hash
     hash["glance"]["mysql_instance"] = ""
     begin
       mysql = Barclamp.find_by_name("mysql")
@@ -77,7 +77,7 @@ class GlanceService < ServiceObject
     hash["glance"]["api"]["bind_open_address"] = true
     hash["glance"]["registry"]["bind_open_address"] = true
 
-    base.config_hash = hash
+    base.current_config.config_hash = hash
 
     @logger.debug("Glance create_proposal: exiting")
     base


### PR DESCRIPTION
In this pull request set, the following things are addressed:
1. Addition of a mostly complete unit test for the proposal_config model
2. Clean-up of warnings in the BDD code in both crowbar and network barclamps
3. Fix error/bug in keystone that keep it from being created.
4. Fix error/bug in glance that keep it from being created.
5. Fix/change update_proposal_status to operate on the proposal_config and not the active proposal.

As a side effect of the unit test for proposal_config, there are lots of
bugs fixed with the side effect that the mysql barclamp can be create and committed.

With the fix to keystone, glance, and the proposal update function, glance and keystone deploy.

 crowbar_framework/app/models/glance_service.rb |    6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: f9a4b0b232ba0d5c60bf89d5cf3cd43798dfe8a0

Crowbar-Release: development
