### PR TITLE
Get Pebbles to be able to deploy Nova and spin up vms. [3/6]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -4,7 +4,7 @@
   "attributes": {
     "glance": {
       "images": [
-        "http://|ADMINWEB|/files/ami/ubuntu-11.04-server-cloudimg-amd64.tar.gz"
+        "http://|ADMINWEB|/files/ami/ubuntu-12.04-server-cloudimg-amd64.tar.gz"
       ],
       "api": {
         "verbose": true,

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -94,25 +94,14 @@ locale_additions:
           deployment: Deployment
 
 debs:
-  ubuntu-10.10:
-    repos:
-      - deb http://ops.rcb.me/packages maverick diablo-final
-  ubuntu-11.04:
-    repos:
-      - deb http://ops.rcb.me/packages natty diablo-final
-  ubuntu-11.10:
-    repos:
-      - deb http://ops.rcb.me/packages oneiric diablo-final
-  ubuntu-12.04:
-    pkgs:
-      - sqlite3
   pkgs:
+    - sqlite3
     - glance
     - python-glance
     - python-keystone
 
 extra_files:
-  - http://uec-images.ubuntu.com/releases/11.04/release/ubuntu-11.04-server-cloudimg-amd64.tar.gz ami
-
+  - http://uec-images.ubuntu.com/releases/12.04.2/release/ubuntu-12.04-server-cloudimg-amd64.tar.gz ami
+  
 git_repo:
   - glance https://github.com/openstack/glance.git stable/grizzly


### PR DESCRIPTION
These pull request updates allow Nova and all its prerequisites to
deploy using their default proposals, and test that Nova is able to
spin up a VM.

We still need to have proper smoketests for Quantum and Cinder, and
the Nova smoketests need to include testing attaching and detaching
networks and volumes to vms.

 chef/data_bags/crowbar/bc-template-glance.json |    2 +-
 crowbar.yml                                    |   17 +++--------------
 2 files changed, 4 insertions(+), 15 deletions(-)

Crowbar-Pull-ID: a0c8ce902ba2ff2b08a2b4fcf2938992f2e17f34

Crowbar-Release: pebbles
