### PR TITLE
Remove possibility to use sqlite

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -60,7 +60,6 @@ default[:glance][:working_directory]="/var/lib/glance"
 default[:glance][:pid_directory]="/var/run/glance"
 default[:glance][:image_cache_datadir] = "/var/lib/glance/image-cache/"
 
-default[:glance][:sql_connection] = "sqlite:////var/lib/glance/glance.sqlite"
 default[:glance][:sql_idle_timeout] = "3600"
 
 #default_store choices are: file, http, https, swift, s3

--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -63,9 +63,7 @@
       "use_keystone": true,
       "keystone_instance": "none",
       "service_user": "glance",
-      "database_engine": "database",
-      "database_instance": "none",
-      "sqlite_connection": "sqlite:////var/lib/glance/glance.sqlite"
+      "database_instance": "none"
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -59,9 +59,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str" },
-            "database_engine": { "type": "str", "required": true },
-            "database_instance": { "type": "str", "required": true },
-            "sqlite_connection": { "type": "str", "required": true }
+            "database_instance": { "type": "str", "required": true }
           }
         }
       }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -58,9 +58,7 @@ locale_additions:
           image_cache_grace_period: Grace Period
           image_cache_stall_timeout: Stall Timeout
           database_header: Database
-          database_engine: Database Engine
           sql_idle_timeout: SQL Idle Timeout
-          sqlite_connection: SQLite Connection String
           database_instance: Database Instance
           use_keystone: Use Keystone
           keystone_instance: Keystone Instance


### PR DESCRIPTION
It's known to be broken, and there was agreement to only use the
database barclamp.

This means we can remove the whole database_engine dance, which
simplifies things.

Note: changes in common.rb look big but are mostly indentation-related due to removal of an "if" statement.
