### PR TITLE
The keystone auth_token middleware has been move to keystoneclient [3/4]

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api-paste.ini.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api-paste.ini.erb
@@ -70,7 +70,7 @@ paste.filter_factory = glance.api.middleware.cache_manage:CacheManageFilter.fact
 paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 
 [filter:authtoken]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_address %>
 service_port = <%= @keystone_service_port %>

--- a/chef/cookbooks/glance/templates/default/glance-registry-paste.ini.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry-paste.ini.erb
@@ -17,7 +17,7 @@ paste.app_factory = glance.registry.api.v1:API
 paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 
 [filter:authtoken]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_address %>
 service_port = <%= @keystone_service_port %>


### PR DESCRIPTION
Using keystone.middleware.auth_token causes problems on nodes that don't have
the server side of keystone installed.

 chef/cookbooks/glance/templates/default/glance-api-paste.ini.erb      | 2 +-
 chef/cookbooks/glance/templates/default/glance-registry-paste.ini.erb | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 197808408153b82a03525bc760b96ecadfb330c3

Crowbar-Release: pebbles
