### PR TITLE
Add non-configurable attribute for http/https use in keystone [2/7]

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -21,6 +21,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_protocol = keystone["keystone"]["api"]["protocol"]
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_service_port = keystone["keystone"]["api"]["service_port"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
@@ -39,6 +40,7 @@ if node[:glance][:use_keystone]
   end
 
 else
+  keystone_protocol = ""
   keystone_address = ""
   keystone_token = ""
   keystone_service_port = ""
@@ -53,6 +55,7 @@ template node[:glance][:api][:config_file] do
   group "root"
   mode 0640
   variables(
+      :keystone_protocol => keystone_protocol,
       :keystone_address => keystone_address,
       :keystone_service_port => keystone_service_port,
       :keystone_service_user => keystone_service_user,
@@ -67,6 +70,7 @@ template node[:glance][:api][:paste_ini] do
   group "root"
   mode 0640
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_address => keystone_address,
     :keystone_auth_token => keystone_token,
     :keystone_service_port => keystone_service_port,
@@ -99,6 +103,7 @@ if node[:glance][:use_keystone]
   api_port = node["glance"]["api"]["bind_port"]
 
   keystone_register "glance api wakeup keystone" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -106,6 +111,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "register glance user" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -116,6 +122,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "give glance user access" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -126,6 +133,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "register glance service" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -136,6 +144,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "register glance endpoint" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -21,6 +21,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_protocol = keystone["keystone"]["api"]["protocol"]
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
   keystone_service_port = keystone["keystone"]["api"]["service_port"]
@@ -29,6 +30,7 @@ if node[:glance][:use_keystone]
   keystone_service_password = node[:glance][:service_password]
   Chef::Log.info("Keystone server found at #{keystone_address}")
 else
+  keystone_protocol = ""
   keystone_address = ""
   keystone_token = ""
 end
@@ -46,6 +48,7 @@ template node[:glance][:registry][:paste_ini] do
   group "root"
   mode 0640
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_address => keystone_address,
     :keystone_auth_token => keystone_token,
     :keystone_service_port => keystone_service_port,
@@ -76,6 +79,7 @@ if node[:glance][:use_keystone]
   api_port = node["glance"]["api"]["bind_port"]
 
   keystone_register "glance registry wakeup keystone" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -83,6 +87,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "register glance user" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token
@@ -93,6 +98,7 @@ if node[:glance][:use_keystone]
   end
 
   keystone_register "give glance user access" do
+    protocol keystone_protocol
     host keystone_address
     port keystone_admin_port
     token keystone_token

--- a/chef/cookbooks/glance/recipes/setup.rb
+++ b/chef/cookbooks/glance/recipes/setup.rb
@@ -27,7 +27,7 @@ if node[:glance][:use_keystone]
   admin_token = "-I #{keystone["keystone"]["admin"]["username"]}"
   admin_token = "#{admin_token} -K #{keystone["keystone"]["admin"]["password"]}"
   admin_token = "#{admin_token} -T #{keystone["keystone"]["admin"]["tenant"]}"
-  admin_token = "#{admin_token} -N http://#{key_ip}:#{keystone["keystone"]["api"]["api_port"]}/v2.0"
+  admin_token = "#{admin_token} -N #{keystone["keystone"]["api"]["protocol"]}://#{key_ip}:#{keystone["keystone"]["api"]["api_port"]}/v2.0"
 else
   admin_token = ""
 end

--- a/chef/cookbooks/glance/templates/default/glance-api-paste.ini.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api-paste.ini.erb
@@ -71,13 +71,13 @@ paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 
 [filter:authtoken]
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
-service_protocol = http
+service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_address %>
 service_port = <%= @keystone_service_port %>
-auth_protocol = http
+auth_protocol = <%= @keystone_protocol %>
 auth_host = <%= @keystone_address %>
 auth_port = <%= @keystone_admin_port %>
-auth_uri = http://<%= @keystone_address %>:<%= @keystone_service_port %>/
+auth_uri = <%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_service_port %>/
 admin_token = <%= @keystone_auth_token %>
 admin_tenant_name = <%= @keystone_service_tenant %>
 admin_user = <%= @keystone_service_user %>

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -70,7 +70,7 @@ filesystem_store_datadir = <%= node[:glance][:filesystem_store_datadir] %>
 # ============ Swift Store Options =============================
 
 # Address where the Swift authentication service lives
-swift_store_auth_address = http://<%= @keystone_address %>:<%= @keystone_service_port %>/v2.0/
+swift_store_auth_address = <%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_service_port %>/v2.0/
 
 # Ensure we'll be using version 2 when authenticating with Keystone
 swift_store_auth_version = 2.0

--- a/chef/cookbooks/glance/templates/default/glance-registry-paste.ini.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry-paste.ini.erb
@@ -18,13 +18,13 @@ paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
 
 [filter:authtoken]
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
-service_protocol = http
+service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_address %>
 service_port = <%= @keystone_service_port %>
-auth_protocol = http
+auth_protocol = <%= @keystone_protocol %>
 auth_host = <%= @keystone_address %>
 auth_port = <%= @keystone_admin_port %>
-auth_uri = http://<%= @keystone_address %>:<%= @keystone_service_port %>/
+auth_uri = <%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_service_port %>/
 admin_token = <%= @keystone_auth_token %>
 admin_tenant_name = <%= @keystone_service_tenant %>
 admin_user = <%= @keystone_service_user %>


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
