### PR TITLE
Don't hardcode the username in cron files (bnc#826117).

### DIFF
--- a/chef/cookbooks/glance/recipes/cache.rb
+++ b/chef/cookbooks/glance/recipes/cache.rb
@@ -84,6 +84,7 @@ if node[:glance][:enable_caching]
     variables(
       :glance_min => "5",
       :glance_hour => "*",
+      :glance_user => node[:glance][:user],
       :glance_command => "/usr/bin/glance-cache-reaper")
   end
 
@@ -95,6 +96,7 @@ if node[:glance][:enable_caching]
     variables(
       :glance_min => "45",
       :glance_hour => "*",
+      :glance_user => node[:glance][:user],
       :glance_command => "/usr/bin/glance-cache-pruner")
   end
 
@@ -106,6 +108,7 @@ if node[:glance][:enable_caching]
     variables(
       :glance_min => "25",
       :glance_hour => "*",
+      :glance_user => node[:glance][:user],
       :glance_command => "/usr/bin/glance-cache-prefetcher")
   end
 

--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -33,6 +33,7 @@ template "/etc/cron.d/glance-scrubber" do
   variables(
     :glance_min => "1",
     :glance_hour => "*",
+    :glance_user => node[:glance][:user],
     :glance_command => "/usr/bin/glance-scrubber")
 end
 

--- a/chef/cookbooks/glance/templates/default/glance.cron.erb
+++ b/chef/cookbooks/glance/templates/default/glance.cron.erb
@@ -8,6 +8,6 @@ SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user	command
-<%= @glance_min %> <%= @glance_hour %>	* * *	glance    <%= @glance_command %>
+<%= @glance_min %> <%= @glance_hour %>	* * *	<%= @glance_user %>    <%= @glance_command %>
 
 


### PR DESCRIPTION
In our tests it surfaced in /etc/cron.d/glance-scrubber.
In SUSE packages the user is openstack-glance.

Regarding possible other occurrences of the bug: AFAIK the only other barclamp with cron files is swift and there the username is variable already.
