### PR TITLE
Move registration of glance service user to common recipe

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -102,36 +102,6 @@ if node[:glance][:use_keystone]
   my_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
   api_port = node["glance"]["api"]["bind_port"]
 
-  keystone_register "glance api wakeup keystone" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    action :wakeup
-  end
-
-  keystone_register "register glance user" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    user_name keystone_service_user
-    user_password keystone_service_password
-    tenant_name keystone_service_tenant
-    action :add_user
-  end
-
-  keystone_register "give glance user access" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    user_name keystone_service_user
-    tenant_name keystone_service_tenant
-    role_name "admin"
-    action :add_access
-  end
-
   keystone_register "register glance service" do
     protocol keystone_protocol
     host keystone_address

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -126,3 +126,54 @@ node[:glance][:sql_connection] = "#{url_scheme}://#{node[:glance][:db][:user]}:#
 
 node.save
 
+# Register glance service user
+
+if node[:glance][:use_keystone]
+  env_filter = " AND keystone_config_environment:keystone-config-#{node[:glance][:keystone_instance]}"
+  keystones = search(:node, "recipes:keystone\\:\\:server#{env_filter}") || []
+  if keystones.length > 0
+    keystone = keystones[0]
+    keystone = node if keystone.name == node.name
+  else
+    keystone = node
+  end
+
+  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_protocol = keystone["keystone"]["api"]["protocol"]
+  keystone_token = keystone["keystone"]["service"]["token"]
+  keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
+  keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
+  keystone_service_user = node[:glance][:service_user]
+  keystone_service_password = node[:glance][:service_password]
+  Chef::Log.info("Keystone server found at #{keystone_address}")
+
+  keystone_register "glance wakeup keystone" do
+    protocol keystone_protocol
+    host keystone_address
+    port keystone_admin_port
+    token keystone_token
+    action :wakeup
+  end
+
+  keystone_register "register glance user" do
+    protocol keystone_protocol
+    host keystone_address
+    port keystone_admin_port
+    token keystone_token
+    user_name keystone_service_user
+    user_password keystone_service_password
+    tenant_name keystone_service_tenant
+    action :add_user
+  end
+
+  keystone_register "give glance user access" do
+    protocol keystone_protocol
+    host keystone_address
+    port keystone_admin_port
+    token keystone_token
+    user_name keystone_service_user
+    tenant_name keystone_service_tenant
+    role_name "admin"
+    action :add_access
+  end
+end

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -75,40 +75,6 @@ bash "Sync registry glance db" do
   action :nothing
 end
 
-if node[:glance][:use_keystone]
-  api_port = node["glance"]["api"]["bind_port"]
-
-  keystone_register "glance registry wakeup keystone" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    action :wakeup
-  end
-
-  keystone_register "register glance user" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    user_name keystone_service_user
-    user_password keystone_service_password
-    tenant_name keystone_service_tenant
-    action :add_user
-  end
-
-  keystone_register "give glance user access" do
-    protocol keystone_protocol
-    host keystone_address
-    port keystone_admin_port
-    token keystone_token
-    user_name keystone_service_user
-    tenant_name keystone_service_tenant
-    role_name "admin"
-    action :add_access
-  end
-end
-
 glance_service "registry"
 
 node[:glance][:monitor][:svcs] << ["glance-registry"]


### PR DESCRIPTION
There's no need to have that code done twice for both api and registry,
which was also causing a CHEF-3694 bug (since the resources had the same
name).

WARN: Cloning resource attributes for keystone_register[register glance user] from prior resource (CHEF-3694)
WARN: Previous keystone_register[register glance user]: /var/chef/cache/cookbooks/glance/recipes/api.rb:108:in `from_file'
WARN: Current  keystone_register[register glance user]: /var/chef/cache/cookbooks/glance/recipes/registry.rb:85:in`from_file'
WARN: Cloning resource attributes for keystone_register[give glance user access] from prior resource (CHEF-3694)
WARN: Previous keystone_register[give glance user access]: /var/chef/cache/cookbooks/glance/recipes/api.rb:118:in `from_file'
WARN: Current  keystone_register[give glance user access]: /var/chef/cache/cookbooks/glance/recipes/registry.rb:95:in`from_file
