### PR TITLE
Unbreak current code so that proposal can apply

### DIFF
--- a/chef/cookbooks/glance/definitions/glance_service.rb
+++ b/chef/cookbooks/glance/definitions/glance_service.rb
@@ -14,7 +14,6 @@ define :glance_service do
     supports :status => true, :restart => true
     action [:enable, :start]
     subscribes :restart, resources(:template => node[:glance][short_name][:config_file]), :immediately
-    subscribes :restart, resources(:template => node[:glance][short_name][:paste_ini]), :immediately
   end
 
 end


### PR DESCRIPTION
Commit 922b3c89 removed the paste_ini attributes, because the paste.ini
files won't be changed anymore. So there's no need to subscribe to them.
