### PR TITLE
Always make glance-registry bind to admin IP address

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -6,7 +6,7 @@ verbose = <%= node[:glance][:verbose] ? "True" : "False" %>
 debug = <%= node[:glance][:debug] ? "True" : "False" %>
 
 # Address to bind the registry server
-bind_host = <%= node[:glance][:registry][:bind_open_address] ? "0.0.0.0" : node[:glance][:registry][:bind_host] %>
+bind_host = <%= node[:glance][:registry][:bind_host] %>
 
 # Port the bind the registry server to
 bind_port = <%= node[:glance][:registry][:bind_port] %>

--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -13,7 +13,6 @@
         "bind_port": 9292
       },
       "registry": {
-        "bind_open_address": true,
         "bind_port": 9191
       },
       "enable_caching": false,

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -31,7 +31,6 @@
               "type": "map",
               "required": true,
               "mapping": {
-                "bind_open_address": { "type": "bool", "required": true },
                 "bind_port": { "type": "int", "required": true }
               }
             },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -49,8 +49,6 @@ locale_additions:
           swift_store_key: Glance Swift Key
           api_header: API
           api_bind_open_address: Bind to All Addresses
-          registry_header: Registry
-          registry_bind_open_address: Bind to All Addresses
           cache_header: Caching
           enable_caching: Enable Caching
           use_cachemanagement: Turn On Cache Management

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -33,12 +33,6 @@
         %label{ :for => :api_bind_open_address }= t('.api_bind_open_address')
         = select_tag :api_bind_open_address, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["api"]["bind_open_address"].to_s), :onchange => "update_value('api/bind_open_address', 'api_bind_open_address', 'boolean')"
     %p
-      %label{ :for => :registry_header }= t('.registry_header')
-    %div.container
-      %p
-        %label{ :for => :registry_bind_open_address }= t('.registry_bind_open_address')
-        = select_tag :registry_bind_open_address, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["registry"]["bind_open_address"].to_s), :onchange => "update_value('registry/bind_open_address', 'registry_bind_open_address', 'boolean')"
-    %p
       %label{ :for => :cache_header }= t('.cache_header')
     %div.container
       %p


### PR DESCRIPTION
glance-registry is not public and is only used internally to OpenStack.
So it doesn't make sense to make it accessible from public IP addresses.
