### PR TITLE
Register endpoints with public name and FQDN when possible

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -20,7 +20,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_host = keystone[:fqdn]
   keystone_protocol = keystone["keystone"]["api"]["protocol"]
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_service_port = keystone["keystone"]["api"]["service_port"]
@@ -28,7 +28,7 @@ if node[:glance][:use_keystone]
   keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
   keystone_service_user = node[:glance][:service_user]
   keystone_service_password = node[:glance][:service_password]
-  Chef::Log.info("Keystone server found at #{keystone_address}")
+  Chef::Log.info("Keystone server found at #{keystone_host}")
 
   if node[:glance][:use_gitrepo]
     pfs_and_install_deps "keystone" do
@@ -41,7 +41,7 @@ if node[:glance][:use_keystone]
 
 else
   keystone_protocol = ""
-  keystone_address = ""
+  keystone_host = ""
   keystone_token = ""
   keystone_service_port = ""
   keystone_service_tenant = ""
@@ -56,7 +56,7 @@ template node[:glance][:api][:config_file] do
   mode 0640
   variables(
       :keystone_protocol => keystone_protocol,
-      :keystone_address => keystone_address,
+      :keystone_host => keystone_host,
       :keystone_admin_port => keystone_admin_port,
       :keystone_service_port => keystone_service_port,
       :keystone_service_user => keystone_service_user,
@@ -82,12 +82,26 @@ bash "Sync api glance db" do
 end
 
 if node[:glance][:use_keystone]
+
+  my_admin_host = node[:fqdn]
+  # For the public endpoint, we prefer the public name. If not set, then we
+  # use the IP address except for SSL, where we always prefer a hostname
+  # (for certificate validation).
+  my_public_host = node[:crowbar][:public_name]
+  if my_public_host.nil? or my_public_host.empty?
+    unless node[:glance][:api][:protocol] == "https"
+      my_public_host = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+    else
+      my_public_host = 'public.'+node[:fqdn]
+    end
+  end
+
   # If we let the service bind to all IPs, then the service is obviously usable
   # from the public network. Otherwise, the endpoint URL should use the unique
   # IP that will be listened on.
   if node[:glance][:api][:bind_open_address]
-    endpoint_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-    endpoint_public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+    endpoint_admin_ip = my_admin_host
+    endpoint_public_ip = my_public_host
   else
     endpoint_admin_ip = node[:glance][:api][:bind_host]
     endpoint_public_ip = node[:glance][:api][:bind_host]
@@ -96,7 +110,7 @@ if node[:glance][:use_keystone]
 
   keystone_register "register glance service" do
     protocol keystone_protocol
-    host keystone_address
+    host keystone_host
     port keystone_admin_port
     token keystone_token
     service_name "glance"
@@ -107,7 +121,7 @@ if node[:glance][:use_keystone]
 
   keystone_register "register glance endpoint" do
     protocol keystone_protocol
-    host keystone_address
+    host keystone_host
     port keystone_admin_port
     token keystone_token
     endpoint_service "glance"

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -138,18 +138,18 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_host = keystone[:fqdn]
   keystone_protocol = keystone["keystone"]["api"]["protocol"]
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
   keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
   keystone_service_user = node[:glance][:service_user]
   keystone_service_password = node[:glance][:service_password]
-  Chef::Log.info("Keystone server found at #{keystone_address}")
+  Chef::Log.info("Keystone server found at #{keystone_host}")
 
   keystone_register "glance wakeup keystone" do
     protocol keystone_protocol
-    host keystone_address
+    host keystone_host
     port keystone_admin_port
     token keystone_token
     action :wakeup
@@ -157,7 +157,7 @@ if node[:glance][:use_keystone]
 
   keystone_register "register glance user" do
     protocol keystone_protocol
-    host keystone_address
+    host keystone_host
     port keystone_admin_port
     token keystone_token
     user_name keystone_service_user
@@ -168,7 +168,7 @@ if node[:glance][:use_keystone]
 
   keystone_register "give glance user access" do
     protocol keystone_protocol
-    host keystone_address
+    host keystone_host
     port keystone_admin_port
     token keystone_token
     user_name keystone_service_user

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -20,7 +20,7 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+  keystone_host = keystone[:fqdn]
   keystone_protocol = keystone["keystone"]["api"]["protocol"]
   keystone_token = keystone["keystone"]["service"]["token"]
   keystone_admin_port = keystone["keystone"]["api"]["admin_port"]
@@ -28,10 +28,10 @@ if node[:glance][:use_keystone]
   keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
   keystone_service_user = node[:glance][:service_user]
   keystone_service_password = node[:glance][:service_password]
-  Chef::Log.info("Keystone server found at #{keystone_address}")
+  Chef::Log.info("Keystone server found at #{keystone_host}")
 else
   keystone_protocol = ""
-  keystone_address = ""
+  keystone_host = ""
   keystone_token = ""
   keystone_service_port = ""
   keystone_service_tenant = ""
@@ -46,7 +46,7 @@ template node[:glance][:registry][:config_file] do
   mode 0640
   variables(
       :keystone_protocol => keystone_protocol,
-      :keystone_address => keystone_address,
+      :keystone_host => keystone_host,
       :keystone_admin_port => keystone_admin_port,
       :keystone_service_port => keystone_service_port,
       :keystone_service_user => keystone_service_user,

--- a/chef/cookbooks/glance/recipes/setup.rb
+++ b/chef/cookbooks/glance/recipes/setup.rb
@@ -23,11 +23,10 @@ if node[:glance][:use_keystone]
     keystone = node
   end
 
-  key_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address
   admin_token = "-I #{keystone["keystone"]["admin"]["username"]}"
   admin_token = "#{admin_token} -K #{keystone["keystone"]["admin"]["password"]}"
   admin_token = "#{admin_token} -T #{keystone["keystone"]["admin"]["tenant"]}"
-  admin_token = "#{admin_token} -N #{keystone["keystone"]["api"]["protocol"]}://#{key_ip}:#{keystone["keystone"]["api"]["api_port"]}/v2.0"
+  admin_token = "#{admin_token} -N #{keystone["keystone"]["api"]["protocol"]}://#{keystone[:fqdn]}:#{keystone["keystone"]["api"]["api_port"]}/v2.0"
 else
   admin_token = ""
 end

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -208,7 +208,7 @@ swift_store_auth_version = 2.0
 # Valid schemes are 'http://' and 'https://'
 # If no scheme specified,  default to 'https://'
 # For swauth, use something like '127.0.0.1:8080/v1.0/'
-swift_store_auth_address = <%= @keystone_protocol %>://<%= @keystone_address %>:<%= @keystone_service_port %>/v2.0/
+swift_store_auth_address = <%= @keystone_protocol %>://<%= @keystone_host %>:<%= @keystone_service_port %>/v2.0/
 
 # User to authenticate against the Swift authentication service
 # If you use Swift authentication service, set it to 'account':'user'
@@ -338,7 +338,7 @@ scrubber_datadir = /var/lib/glance/scrubber
 image_cache_dir = <%= node[:glance][:image_cache_dir] %>
 
 [keystone_authtoken]
-auth_host = <%= @keystone_address %>
+auth_host = <%= @keystone_host %>
 auth_port = <%= @keystone_admin_port %>
 auth_protocol = <%= @keystone_protocol %>
 admin_tenant_name = <%= @keystone_service_tenant %>

--- a/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-registry.conf.erb
@@ -72,7 +72,7 @@ use_syslog = <%= node[:glance][:use_syslog] ? "True" : "False" %>
 #ca_file = /path/to/cafile
 
 [keystone_authtoken]
-auth_host = <%= @keystone_address %>
+auth_host = <%= @keystone_host %>
 auth_port = <%= @keystone_admin_port %>
 auth_protocol = <%= @keystone_protocol %>
 admin_tenant_name = <%= @keystone_service_tenant %>


### PR DESCRIPTION
When using SSL, the common name field in the certificates is checked,
and using IP addresses won't work with that.

Internally to the OpenStack setup, it is always fine to use the FQDN
from the node, so we use this in the internal and admin URLs of the
endpoints.

For the public URL, we prefer to use the public name if it is set. If it
it not set, then we use the public FQDN only if SSL is enabled;
otherwise, we prefer the IP address (like before) because we're not 100%
sure that the administrator will have completed a proper DNS setup where
the public FQDN generated by Crowbar will be announced externally.
