### PR TITLE
Fix initial call to glance-manage

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -29,16 +29,6 @@ if node[:glance][:use_keystone]
   keystone_service_user = node[:glance][:service_user]
   keystone_service_password = node[:glance][:service_password]
   Chef::Log.info("Keystone server found at #{keystone_host}")
-
-  if node[:glance][:use_gitrepo]
-    pfs_and_install_deps "keystone" do
-      cookbook "keystone"
-      cnode keystone
-      path File.join(glance_path,"keystone")
-      virtualenv venv_path
-    end
-  end
-
 else
   keystone_protocol = ""
   keystone_host = ""
@@ -78,22 +68,6 @@ template node[:glance][:api][:config_file] do
       :keystone_service_password => keystone_service_password,
       :keystone_service_tenant => keystone_service_tenant
   )
-end
-
-bash "Set api glance version control" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "exit 0"
-  notifies :run, "bash[Sync api glance db]", :immediately
-  only_if "#{venv_prefix}glance-manage version_control 0", :user => node[:glance][:user], :group => node[:glance][:group]
-  action :run
-end
-
-bash "Sync api glance db" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "#{venv_prefix}glance-manage db_sync"
-  action :nothing
 end
 
 if node[:glance][:use_keystone]

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -29,6 +29,16 @@ if node[:glance][:use_keystone]
   keystone_service_user = node[:glance][:service_user]
   keystone_service_password = node[:glance][:service_password]
   Chef::Log.info("Keystone server found at #{keystone_host}")
+
+  if node[:glance][:use_gitrepo]
+    pfs_and_install_deps "keystone" do
+      cookbook "keystone"
+      cnode keystone
+      path File.join(glance_path,"keystone")
+      virtualenv venv_path
+    end
+  end
+
 else
   keystone_protocol = ""
   keystone_host = ""
@@ -55,16 +65,16 @@ template node[:glance][:registry][:config_file] do
   )
 end
 
-bash "Set registry glance version control" do
+bash "Set glance version control" do
   user node[:glance][:user]
   group node[:glance][:group]
   code "exit 0"
-  notifies :run, "bash[Sync registry glance db]", :immediately
+  notifies :run, "bash[Sync glance db]", :immediately
   only_if "#{venv_prefix}glance-manage version_control 0", :user => node[:glance][:user], :group => node[:glance][:group]
   action :run
 end
 
-bash "Sync registry glance db" do
+bash "Sync glance db" do
   user node[:glance][:user]
   group node[:glance][:group]
   code "#{venv_prefix}glance-manage db_sync"

--- a/chef/roles/glance-server.rb
+++ b/chef/roles/glance-server.rb
@@ -1,8 +1,8 @@
 name "glance-server"
 description "Glance Server Role - Image Registry and Delivery Service for the cloud"
 run_list(
-         "recipe[glance::api]",
          "recipe[glance::registry]",
+         "recipe[glance::api]",
          "recipe[glance::cache]",
          "recipe[glance::scrubber]",
          "recipe[glance::setup]",


### PR DESCRIPTION
Right now, on installation of glance, there will be a glance-manage
crash (visible in the glance-registry log). This is because we run
glance-manage in the api recipe, before glance-registry.conf is created
while glance-manage read settings from the glance-registry.conf file.

As it makes no sense to call glance-manage twice, we can simply stop
calling it from the api recipe and call it from the registry recipe; we
also make the registry recipe run before the api one.
