### PR TITLE
Stop installing python-keystone package

### DIFF
--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -27,9 +27,6 @@ package "curl" do
 end
 
 unless node[:glance][:use_gitrepo]
-  package "python-keystone" do
-    action :install
-  end
   package "glance" do
     package_name "openstack-glance" if node.platform == "suse"
     options "--force-yes" if node.platform != "suse"


### PR DESCRIPTION
This is not needed since commit 930f273, when we moved to using
keystoneclient.middleware.auth_token.
