### PR TITLE
Allow to auto-generate self-signed SSL certificates

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -68,8 +68,9 @@ node[:glance][:monitor]={}
 node[:glance][:monitor][:svcs] = []
 node[:glance][:monitor][:ports]={}
 
-default[:glance][:ssl][:insecure] = false
 default[:glance][:ssl][:certfile] = "/etc/glance/ssl/certs/signing_cert.pem"
 default[:glance][:ssl][:keyfile] = "/etc/glance/ssl/private/signing_key.pem"
+default[:glance][:ssl][:generate_certs] = false
+default[:glance][:ssl][:insecure] = false
 default[:glance][:ssl][:cert_required] = false
 default[:glance][:ssl][:ca_certs] = "/etc/glance/ssl/certs/ca.pem"

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -40,6 +40,54 @@ else
 end
 
 if node[:glance][:api][:protocol] == 'https'
+  if node[:glance][:ssl][:generate_certs]
+    package "openssl"
+
+    require "fileutils"
+    [:certfile, :keyfile, :ca_certs].each do |k|
+      dir = File.dirname(node[:glance][:ssl][k])
+      if File.exists?(dir)
+        FileUtils.chown_R node[:glance][:user], node[:glance][:group], dir
+      else
+        FileUtils.mkdir_p(dir) {|d| File.chown node[:glance][:user], node[:glance][:group], d}
+      end
+    end
+
+    # Some more ownership fixes:
+    conf_dir = File.dirname node[:glance][:ssl][:ca_certs]
+    FileUtils.chown "root", node[:glance][:group], conf_dir
+    FileUtils.chown "root", node[:glance][:group], File.expand_path("#{conf_dir}/..")  # /etc/glance/ssl
+
+    # Generate private key
+    %x(openssl genrsa -out #{node[:glance][:ssl][:keyfile]} 4096)
+    if $?.exitstatus != 0
+      message = "SSL private key generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+    FileUtils.chown node[:glance][:user], node[:glance][:group], node[:glance][:ssl][:keyfile]
+
+    # Generate certificate signing requests (CSR)
+    ssl_csr_file = "#{conf_dir}/signing_key.csr"
+    ssl_subject = "\"/C=US/ST=Unset/L=Unset/O=Unset/CN=#{node[:fqdn]}\""
+    %x(openssl req -new -key #{node[:glance][:ssl][:keyfile]} -out #{ssl_csr_file} -subj #{ssl_subject})
+    if $?.exitstatus != 0
+      message = "SSL certificate signed requests generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    # Generate self-signed certificate with above CSR
+    %x(openssl x509 -req -days 3650 -in #{ssl_csr_file} -signkey #{node[:glance][:ssl][:keyfile]} -out #{node[:glance][:ssl][:certfile]})
+    if $?.exitstatus != 0
+      message = "SSL self-signed certificate generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    File.delete ssl_csr_file  # Nobody should even try to use this
+  end
+
   unless ::File.exists? node[:glance][:ssl][:certfile]
     message = "Certificate \"#{node[:glance][:ssl][:certfile]}\" is not present."
     Chef::Log.fatal(message)

--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -17,9 +17,10 @@
         "bind_port": 9191
       },
       "ssl": {
-        "insecure": false,
         "certfile": "/etc/glance/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/glance/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
         "cert_required": false,
         "ca_certs": "/etc/glance/ssl/certs/ca.pem"
       },

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -27,9 +27,10 @@
               }
             },
             "ssl": { "type": "map", "required": true, "mapping": {
-              "insecure": { "type" : "bool", "required" : true },
               "certfile": { "type" : "str", "required" : true },
               "keyfile": { "type" : "str", "required" : true },
+              "generate_certs": { "type" : "bool", "required" : true },
+              "insecure": { "type" : "bool", "required" : true },
               "cert_required": { "type" : "bool", "required" : true },
               "ca_certs": { "type" : "str", "required" : true }
             }},

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -66,6 +66,7 @@ locale_additions:
           ssl_insecure: SSL Certificate is insecure (for instance, auto-signed)
           ssl_certfile: SSL Certificate File
           ssl_keyfile: SSL (Private) Key File
+          ssl_generate_certs: Generate (self-signed) certificates (implies insecure)
           ssl_cert_required: Require Client Certificate
           ssl_ca_certs: SSL CA Certificates File
         edit_deployment: 

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -78,6 +78,9 @@
         %label{ :for => :ssl_keyfile }= t('.ssl_keyfile')
         = text_field_tag :ssl_keyfile, @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["keyfile"], :size => 80, :onchange => "update_value('ssl/keyfile', 'ssl_keyfile', 'string')"
       %p
+        %label{ :for => :ssl_generate_certs }= t('.ssl_generate_certs')
+        = select_tag :ssl_generate_certs, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["generate_certs"].to_s), :onchange => "update_value('ssl/generate_certs', 'ssl_generate_certs', 'boolean')"
+      %p
         %label{ :for => :ssl_insecure }= t('.ssl_insecure')
         = select_tag :ssl_insecure, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["insecure"].to_s), :onchange => "update_value('ssl/insecure', 'ssl_insecure', 'boolean')"
       %p
@@ -105,10 +108,19 @@
     }
   };
 
+  function toggle_ssl_generate_certs() {
+    if ($('#ssl_generate_certs option:selected').attr('value') == 'true') {
+      $('#ssl_insecure').attr('value', 'true');
+      $('#ssl_cert_required').attr('value', 'false');
+    }
+  };
+
   $(document).ready(function () {
     toggle_protocol();
     toggle_ssl_cert_required();
+    toggle_ssl_generate_certs();
   });
 
   $('#protocol').change(toggle_protocol);
   $('#ssl_cert_required').change(toggle_ssl_cert_required);
+  $('#ssl_generate_certs').change(toggle_ssl_generate_certs);


### PR DESCRIPTION
The setup is rather simple. Instead of a full-blown CA, a CSR is used to create the self-signed certificate.
