### PR TITLE
Fix qemu-utils dependency for glance for boot from volume [1/1]

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -6,6 +6,10 @@
 
 include_recipe "#{@cookbook_name}::common"
 
+if node.platform == "ubuntu"
+ package "qemu-utils"
+end
+
 glance_path = "/opt/glance"
 venv_path = node[:glance][:use_virtualenv] ? "#{glance_path}/.venv" : nil
 venv_prefix = node[:glance][:use_virtualenv] ? ". #{venv_path}/bin/activate &&" : nil

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -74,6 +74,7 @@ debs:
     - glance
     - python-glance
     - python-keystone
+    - qemu-utils
 
 extra_files:
   - http://uec-images.ubuntu.com/releases/12.04.2/release/ubuntu-12.04-server-cloudimg-amd64.tar.gz ami


### PR DESCRIPTION
This is fix currently is for ubuntu.
Expect that we will need an analog for all OSes.

 chef/cookbooks/glance/recipes/api.rb |    4 ++++
 crowbar.yml                          |    1 +
 2 files changed, 5 insertions(+)

Crowbar-Pull-ID: 94bae016c146b2a1f56b40edef7b63c223b460af

Crowbar-Release: mesa-1.6.1
