### PR TITLE
Fix glance dependency on qemu-utils for boot from volume [1/2]

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -6,6 +6,10 @@
 
 include_recipe "#{@cookbook_name}::common"
 
+if node.platform == "ubuntu"
+ package "qemu-utils"
+end
+
 glance_path = "/opt/glance"
 venv_path = node[:glance][:use_virtualenv] ? "#{glance_path}/.venv" : nil
 venv_prefix = node[:glance][:use_virtualenv] ? ". #{venv_path}/bin/activate &&" : nil

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -84,6 +84,7 @@ debs:
     - glance
     - python-glance
     - python-keystone
+    - qemu-utils
 
 rpms:
   centos-6.4:


### PR DESCRIPTION
Only fixed for ubuntu.
Need to be fixed for other OSes.

 chef/cookbooks/glance/recipes/api.rb |    4 ++++
 crowbar.yml                          |    1 +
 2 files changed, 5 insertions(+)

Crowbar-Pull-ID: a1820b252d31a11dc14ee350ee45c2856bab8b27

Crowbar-Release: roxy
