### PR TITLE
Havana repo updates to crowbar.yml files for the openstack barclamps [6/9]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -89,10 +89,10 @@ debs:
 rpms:
   centos-6.4:
     repos:
-      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-grizzly/epel-6
+      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
   redhat-6.4:
     repos:
-      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-grizzly/epel-6
+      - rpm http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
   pkgs:
     - openstack-glance
     - python-keystone
@@ -103,4 +103,5 @@ extra_files:
   - http://cloud-images.ubuntu.com/releases/precise/release/ubuntu-12.04-server-cloudimg-amd64.tar.gz ami
   
 git_repo:
-  - glance https://github.com/openstack/glance.git stable/grizzly
+  - glance https://github.com/openstack/glance.git milestone-proposed
+  # - glance https://github.com/openstack/glance.git stable/havana


### PR DESCRIPTION
Updated the crowbar.yml files for the openstack barclamps so that the crowbar-bar-cache could be updated with the latest havana packages

 crowbar.yml |    7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 3bb4c6cc22881de90084cba6ee8a6f1664dffb8c

Crowbar-Release: roxy
