### PR TITLE
Start at least two Glance API workers, limit it to four in total

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -62,7 +62,7 @@ sql_idle_timeout = 3600
 # may improve performance (especially if using SSL with
 # compression turned on). It is typically recommended to set
 # this value to the number of CPUs present on your machine.
-workers = 1
+workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 
 # Role used to identify an authenticated user as administrator
 #admin_role = admin


### PR DESCRIPTION
When only one Glance API worker is running, long running operations
like streaming an image can block the API when it uses a native
backend that is not greenlet'ified (like for example rados) for
several minutes, depending on the image size. Start at least two
API workers to increase chance that the API is still available.
