### PR TITLE
propose glance for controller node

### DIFF
--- a/crowbar_framework/app/models/glance_service.rb
+++ b/crowbar_framework/app/models/glance_service.rb
@@ -44,9 +44,9 @@ class GlanceService < ServiceObject
     nodes = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
     if nodes.size >= 1
-      controller = nodes.find { |n| n if n.intended_role == "controller" } || nodes.first[:fqdn]
+      controller = nodes.find { |n| n.intended_role == "controller" } || nodes.first
       base["deployment"]["glance"]["elements"] = {
-        "glance-server" => [ controller ]
+        "glance-server" => [ controller[:fqdn] ]
       }
     end
 


### PR DESCRIPTION
Use the intended role set for the nodes to propose glance deployment.
(Requires changes in barclamp-crowbar: https://github.com/crowbar/barclamp-crowbar/pull/796)
