### PR TITLE
Set Verbose logging by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -3,7 +3,7 @@
   "description": "Glance service (image registry and delivery service) for the cloud",
   "attributes": {
     "glance": {
-      "verbose": false,
+      "verbose": true,
       "debug": false,
       "images": [
         "http://|ADMINWEB|/files/ami/ubuntu-12.04-server-cloudimg-amd64.tar.gz"


### PR DESCRIPTION
This makes the log files tremendously more useful and does not add
much more overhead overall.
