### PR TITLE
Fix bug where image_cache_stall_timeout configured in GUI is ignored [1/1]

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -15,7 +15,7 @@ image_cache_dir = <%= node[:glance][:image_cache_datadir] %>
 
 # Number of seconds after which we should consider an incomplete image to be
 # stalled and eligible for reaping
-image_cache_stall_time = <%= node[:glance][:image_cache_stall_time] %>
+image_cache_stall_time = <%= node[:glance][:image_cache_stall_timeout] %>
 
 # image_cache_invalid_entry_grace_period - seconds
 #


### PR DESCRIPTION
The glance add/edit form allows you to set the value of image_cache_stall_timeout.  In glance-cache.conf.erb though, it was referencing an attribute called image_cache_stall_time.  This caused image_cache_stall_time to be set to nothing in the resulting glance-cache.conf file.

To test this fix, create a glance proposal setting the value of image_cache_stall_timeout to some value in the GUI, or just note the default value.  Deploy glance, then on the glance node as root:

grep image_cache_stall_time /etc/glance/glance-cache.conf

Verify it is set to the value entered in the GUI.

 .../glance/templates/default/glance-cache.conf.erb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: a5ab246768b7aacb97a6e161dbcbed0632b0a8c5

Crowbar-Release: roxy
