### PR TITLE
Removed unused attribute from glance default.rb [1/1]

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -48,7 +48,6 @@ default[:glance][:scrubber][:log_file] = "/var/log/glance/scrubber.log"
 default[:glance][:scrubber][:config_file]="/etc/glance/glance-scrubber.conf"
 
 default[:glance][:working_directory]="/var/lib/glance"
-default[:glance][:pid_directory]="/var/run/glance"
 default[:glance][:image_cache_datadir] = "/var/lib/glance/image-cache/"
 
 default[:glance][:sql_idle_timeout] = "3600"


### PR DESCRIPTION
The pid_directory attribute in the glance default.rb is not used anywhere in crowbar.  This change removes it.

 chef/cookbooks/glance/attributes/default.rb |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 007a3f27716ac77a861db472991bfba31b2c766d

Crowbar-Release: roxy
