### PR TITLE
Hide use_syslog option from UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -68,6 +68,5 @@
         = t(".logging_header")
 
       = boolean_field :verbose
-      = boolean_field :use_syslog
 
     = render "barclamp/git/pfsdeps"

--- a/crowbar_framework/config/locales/glance.en.yml
+++ b/crowbar_framework/config/locales/glance.en.yml
@@ -37,4 +37,3 @@ en:
         database_instance: Database Instance
         logging_header: Logging
         verbose: Verbose
-        use_syslog: Use Syslog


### PR DESCRIPTION
I don't see any reason to expose it.
