### PR TITLE
set filesystem_store_datadir in scrubber.conf to fix warning

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -45,6 +45,10 @@ registry_port = <%= node[:glance][:registry][:bind_port] %>
 # glance-scrubber and glance-api.
 #lock_path=<None>
 
+# Directory that the Filesystem backend store
+# writes image data to
+filesystem_store_datadir = <%= node[:glance][:filesystem_store_datadir] %>
+
 # ================= Security Options ==========================
 
 # AES key for encrypting store 'location' metadata, including


### PR DESCRIPTION
2014-01-27 17:09:18.901 11137 WARNING glance.store.base
[ce367618-b8c3-4f2b-b2f7-4138669f2b1a None None] Failed to configure store
correctly: Store filesystem could not be configured correctly. Reason: Could
not find filesystem_store_datadir in configuration options. Disabling add
method.
