### PR TITLE
Fix: Sometimes on Ubuntu Glance db initialised not properly

### DIFF
--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -126,6 +126,22 @@ node[:glance][:sql_connection] = "#{url_scheme}://#{node[:glance][:db][:user]}:#
 
 node.save
 
+bash "Set glance version control" do
+  user node[:glance][:user]
+  group node[:glance][:group]
+  code "exit 0"
+  notifies :run, "bash[Sync glance db]", :immediately
+  only_if "#{venv_prefix}glance-manage version_control 0", :user => node[:glance][:user], :group => node[:glance][:group]
+  action :run
+end
+
+bash "Sync glance db" do
+  user node[:glance][:user]
+  group node[:glance][:group]
+  code "#{venv_prefix}glance-manage db_sync"
+  action :nothing
+end
+
 # Register glance service user
 
 if node[:glance][:use_keystone]

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -67,22 +67,6 @@ template node[:glance][:registry][:config_file] do
   )
 end
 
-bash "Set glance version control" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "exit 0"
-  notifies :run, "bash[Sync glance db]", :immediately
-  only_if "#{venv_prefix}glance-manage version_control 0", :user => node[:glance][:user], :group => node[:glance][:group]
-  action :run
-end
-
-bash "Sync glance db" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "#{venv_prefix}glance-manage db_sync"
-  action :nothing
-end
-
 glance_service "registry"
 
 node[:glance][:monitor][:svcs] << ["glance-registry"]


### PR DESCRIPTION
This is fix for issue with incorrect database sync migration on Ubuntu with PostgreSQL backend.

Signs of impact: Glance return 500 error on any request, PostgreSQL database doesn't contain migrations.
