### PR TITLE
Fix: Sometimes on Ubuntu Glance db initialised not properly

### DIFF
--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -126,29 +126,6 @@ node[:glance][:sql_connection] = "#{url_scheme}://#{node[:glance][:db][:user]}:#
 
 node.save
 
-bash "Set glance version control" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "exit 0"
-  notifies :run, "bash[Sync glance db]", :immediately
-  only_if "#{venv_prefix}glance-manage version_control 0", :user => node[:glance][:user], :group => node[:glance][:group]
-  action :run
-end
-
-bash "Sync glance db" do
-  user node[:glance][:user]
-  group node[:glance][:group]
-  code "#{venv_prefix}glance-manage db_sync"
-  if %w(redhat centos suse).include?(node.platform)
-    notifies :restart, "service[openstack-glance-api]", :immediately
-    notifies :restart, "service[openstack-glance-registry]", :immediately
-  else
-    notifies :restart, "service[glance-api]", :immediately
-    notifies :restart, "service[glance-registry]", :immediately
-  end  
-  action :nothing
-end
-
 # Register glance service user
 
 if node[:glance][:use_keystone]


### PR DESCRIPTION
This is fix for issue with incorrect database sync migration on Ubuntu with PostgreSQL backend.

Signs of impact: Glance return 500 error on any request, PostgreSQL database doesn't contain migrations.

comes from #178
