### PR TITLE
Up to date list of required packages

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -93,6 +93,7 @@ rpms:
     repos:
       - bare os-havana 50 http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
   pkgs:
+    - qemu-kvm
     - openstack-glance
     - python-keystone
     - python-keystoneclient


### PR DESCRIPTION
Remove unnecessary packages. Glance does not require sqlite anymore.
