### PR TITLE
Restart glance services when ceph.conf changes

### DIFF
--- a/chef/cookbooks/glance/definitions/glance_service.rb
+++ b/chef/cookbooks/glance/definitions/glance_service.rb
@@ -14,6 +14,7 @@ define :glance_service do
     supports :status => true, :restart => true
     action [:enable, :start]
     subscribes :restart, resources(:template => node[:glance][short_name][:config_file]), :immediately
+    subscribes :restart, resources("template[/etc/ceph/ceph.conf]")
   end
 
 end


### PR DESCRIPTION
It is very likely that new monitors got configured then, and
the daemons need to know about them.

(cherry picked from commit 311882e696a208c1b3755ccd05c79cf1f4736bf3)
