### PR TITLE
Fix qemu-kvm dependency for cinder/nova for centos

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -93,6 +93,7 @@ rpms:
     repos:
       - bare os-havana 50 http://repos.fedorapeople.org/repos/openstack/openstack-havana/epel-6
   pkgs:
+    - qemu-img
     - qemu-kvm
     - openstack-glance
     - python-keystone


### PR DESCRIPTION
The packages have a specific full version of each other in a dependency list. Hence YUM application itself can not always solve the problems with circular dependencies
