### PR TITLE
Update db password migration script to remove node attributes

### DIFF
--- a/chef/data_bags/crowbar/migrate/glance/004_add_db.rb
+++ b/chef/data_bags/crowbar/migrate/glance/004_add_db.rb
@@ -1,9 +1,38 @@
 def upgrade ta, td, a, d
   a['db'] = ta['db']
-  service = ServiceObject.new "fake-logger"
+
+  # we use a class variable to set the same password in the proposal and in the
+  # role; we also try to import the database password from the node that was
+  # deployed
+  unless defined?(@@glance_db_password)
+    service = ServiceObject.new "fake-logger"
+    @@glance_db_password = service.random_password
+  end
+
+  Chef::Search::Query.new.search(:node) do |node|
+    dirty = false
+    unless (node[:glance][:db][:password] rescue nil).nil?
+      unless node[:glance][:db][:password].empty?
+        @@glance_db_password = node[:glance][:db][:password]
+      end
+      node[:glance][:db].delete('password')
+      dirty = true
+    end
+    unless (node[:glance][:db][:database] rescue nil).nil?
+      node[:glance][:db].delete('database')
+      dirty = true
+    end
+    unless (node[:glance][:db][:user] rescue nil).nil?
+      node[:glance][:db].delete('user')
+      dirty = true
+    end
+    node.save if dirty
+  end
+
   # old value that was hard-coded
   a['db']['database'] = "glancedb"
-  a['db']['password'] = service.random_password
+  a['db']['password'] = @@glance_db_password
+
   return a, d
 end
 


### PR DESCRIPTION
On update, we want to use the db password from the proposal / role, and
not the one that might have been generated on the node (through the
cookbook). As the password is a "normal" attribute on the node, but a
"default" attribute on the role, the old one from the node is used.
Which means we really need to remove it to get the new one used.

To minimize config changes, we actually import the password from one
node (which should be good enough in most cases as we allow only one
glance proposal, so only one node should have the password).
