### PR TITLE
switch to using KeystoneHelper.keystone_settings

### DIFF
--- a/chef/cookbooks/glance/libraries/helpers.rb
+++ b/chef/cookbooks/glance/libraries/helpers.rb
@@ -1,29 +1,5 @@
 module GlanceHelper
   class << self
-    def keystone_settings(node)
-      @keystone_settings ||= nil
-
-      if @keystone_settings.nil?
-        # we can't use get_instance from here :/
-        #keystone_node = Chef::Recipe.get_instance('roles:keystone-server')
-        nodes = []
-        Chef::Search::Query.new.search(:node, "roles:keystone-server AND keystone_config_environment:keystone-config-#{node[:glance][:keystone_instance]}") { |o| nodes << o }
-        if nodes.empty?
-          keystone_node = node
-        else
-          keystone_node = nodes[0]
-          keystone_node = node if keystone_node.name == node.name
-        end
-
-        @keystone_settings = KeystoneHelper.keystone_settings(keystone_node)
-        @keystone_settings['service_user'] = node[:glance][:service_user]
-        @keystone_settings['service_password'] = node[:glance][:service_password]
-        Chef::Log.info("Keystone server found at #{@keystone_settings['internal_url_host']}")
-      end
-
-      @keystone_settings
-    end
-
     def network_settings(node)
       @ip ||= Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
       @cluster_admin_ip ||= nil

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -16,7 +16,7 @@ if node.platform == "ubuntu"
  package "qemu-utils"
 end
 
-keystone_settings = GlanceHelper.keystone_settings(node)
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 if node[:glance][:api][:protocol] == 'https'
   if node[:glance][:ssl][:generate_certs]

--- a/chef/cookbooks/glance/recipes/cache.rb
+++ b/chef/cookbooks/glance/recipes/cache.rb
@@ -26,7 +26,7 @@ directory node[:glance][:image_cache_datadir] do
   action :create
 end
 
-keystone_settings = GlanceHelper.keystone_settings(node)
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 template node[:glance][:cache][:config_file] do
   source "glance-cache.conf.erb"

--- a/chef/cookbooks/glance/recipes/common.rb
+++ b/chef/cookbooks/glance/recipes/common.rb
@@ -114,7 +114,7 @@ node.save
 
 # Register glance service user
 
-keystone_settings = GlanceHelper.keystone_settings(node)
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 crowbar_pacemaker_sync_mark "wait-glance_register_user"
 

--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -12,7 +12,7 @@ if node[:glance][:use_gitrepo]
   venv_prefix = node[:glance][:use_virtualenv] ? ". #{venv_path}/bin/activate &&" : nil
 end
 
-keystone_settings = GlanceHelper.keystone_settings(node)
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 if node[:glance][:use_gitrepo]
   pfs_and_install_deps "keystone" do

--- a/chef/cookbooks/glance/recipes/setup.rb
+++ b/chef/cookbooks/glance/recipes/setup.rb
@@ -15,7 +15,7 @@ directory "#{node[:glance][:working_directory]}/raw_images" do
   action :create
 end
 
-keystone_settings = GlanceHelper.keystone_settings(node)
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
 glance_args = "--os-username #{keystone_settings["admin_user"]}"
 glance_args = "#{glance_args} --os-password #{keystone_settings["admin_password"]}"


### PR DESCRIPTION
the new KeystoneHelper should take care of retrieving 
service_user/service_password so we don't have to have a separate helper for
that in the glance cookbook
