### PR TITLE
Add optional crowbar-applied boolean attribute to schema

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -75,6 +75,7 @@
   "deployment": {
     "glance": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "schema-revision": 5,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -109,6 +109,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -31,7 +31,7 @@ crowbar:
   order: 85
   run_order: 85
   chef_order: 85
-  proposal_schema_version: 2
+  proposal_schema_version: 3
 
 debs:
   pkgs:


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after the chef run. This allows the UI to show that the current form of the proposal has been 'applied' successfully (i.e. chef-client completed the run w/ success) and that the proposal was then not modified.

Also update the proposal_schema_revision, so we can add the attribute to schema for ('3rd party') barclamps that currently do not have it.

Refs: https://github.com/crowbar/crowbar/pull/2044 (which adds this attribute to barclamps which lack it), https://github.com/crowbar/barclamp-crowbar/pull/1068 (which marks the proposals as applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
