### PR TITLE
Fix glance-manage db sync happening twice on first chef run

### DIFF
--- a/chef/cookbooks/glance/recipes/registry.rb
+++ b/chef/cookbooks/glance/recipes/registry.rb
@@ -42,7 +42,8 @@ crowbar_pacemaker_sync_mark "wait-glance_db_sync"
 execute "glance-manage db_sync" do
   user node[:glance][:user]
   group node[:glance][:group]
-  command "#{venv_prefix}glance-manage db_sync"
+  # We know the glance-api.conf file is not updated yet, so forcefully ignore it
+  command "#{venv_prefix}glance-manage --config-file \"#{node[:glance][:registry][:config_file]}\" db_sync"
   # We only do the sync the first time, and only if we're not doing HA or if we
   # are the founder of the HA cluster (so that it's really only done once).
   only_if { !node[:glance][:db_synced] && (!node[:glance][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) }


### PR DESCRIPTION
glance-manage is looking at the config files of both glance-api and
glance-registry. When we run it, only glance-registry has been
configured and the connection string for database will be overridden by
the default one from glance-api, which points to sqlite.

This results in the migration happening on start of glance-api, which
breaks HA (since only one node can do the migration).

The fix is to run glance-manage with only the glance-registry config
file which we know is correct.

https://bugzilla.novell.com/show_bug.cgi?id=888584
(cherry picked from commit e1f0897a32ab4f6822d52f4f8a867122d14c7133)
