### PR TITLE
webui: Remove some attributes from webui

### DIFF
--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -3,6 +3,7 @@
     = header @dep_raw, true
 
   .panel-body
+    = instance_field :database
     = instance_field :rabbitmq
     = instance_field :keystone
 
@@ -52,25 +53,10 @@
 
     %fieldset
       %legend
-        = t(".api_header")
-
-      = boolean_field %w(api bind_open_address)
-
-    %fieldset
-      %legend
         = t(".cache_header")
 
       = boolean_field :enable_caching
       = boolean_field :use_cachemanagement
-      = string_field :image_cache_datadir
-      = integer_field :image_cache_stall_timeout
-
-    %fieldset
-      %legend
-        = t(".database_header")
-
-      = integer_field :sql_idle_timeout
-      = instance_field :database
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -19,6 +19,7 @@ en:
   barclamp:
     glance:
       edit_attributes:
+        database_instance: 'Database Instance'
         rabbitmq_instance: 'RabbitMQ'
         keystone_instance: 'Keystone Instance'
         store_header: 'Image Storage'
@@ -40,10 +41,8 @@ en:
           password: 'vCenter Password'
           datastore: 'Datastore Name'
           datacenter_path: 'Datacenter Path'
-        api_header: 'API'
         api:
           protocol: 'Protocol'
-          bind_open_address: 'Bind to All Addresses'
         ssl_header: 'SSL Support'
         ssl:
           generate_certs: 'Generate (self-signed) certificates (implies insecure)'
@@ -55,10 +54,5 @@ en:
         cache_header: 'Caching'
         enable_caching: 'Enable Caching'
         use_cachemanagement: 'Turn On Cache Management'
-        image_cache_datadir: 'Directory'
-        image_cache_stall_timeout: 'Stall Timeout'
-        database_header: 'Database'
-        sql_idle_timeout: 'SQL Idle Timeout'
-        database_instance: 'Database Instance'
         logging_header: 'Logging'
         verbose: 'Verbose Logging'


### PR DESCRIPTION
These settings are not extremely useful, so don't display them anymore.
They're still available in the raw view.

bind_open_address, image_cache_datadir, image_cache_stall_timeout,
sql_idle_timeout
