### PR TITLE
Set known_stores in config file (bnc# 890591)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -20,7 +20,7 @@ default_store = <%= node[:glance][:default_store] %>
 #               glance.store.swift.Store,
 #               glance.store.sheepdog.Store,
 #               glance.store.cinder.Store,
-
+known_stores = glance.store.filesystem.Store,glance.store.http.Store,glance.store.rbd.Store,glance.store.swift.Store
 
 # Maximum image size (in bytes) that may be uploaded through the
 # Glance API server. Defaults to 1 TB.

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -51,7 +51,7 @@ registry_port = <%= @registry_bind_port %>
 #                glance.store.swift.Store,
 #                glance.store.sheepdog.Store,
 #                glance.store.cinder.Store,
-
+known_stores = glance.store.filesystem.Store,glance.store.http.Store,glance.store.rbd.Store,glance.store.swift.Store
 # ============ Filesystem Store Options ========================
 
 # Directory that the Filesystem backend store


### PR DESCRIPTION
All stores are enabled by default if known_stores is not set.
Enable only the stores that are configured correctly so that
no misleading error appears in the logs
