### PR TITLE
Make glance-scrubber.conf owned by root:glance, instead of glance:root

### DIFF
--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -22,9 +22,9 @@ network_settings = GlanceHelper.network_settings(node)
 
 template node[:glance][:scrubber][:config_file] do
   source "glance-scrubber.conf.erb"
-  owner node[:glance][:user]
-  group "root"
-  mode 0600
+  owner "root"
+  group node[:glance][:group]
+  mode 0640
   variables(
     :registry_bind_host => network_settings[:registry][:bind_host],
     :registry_bind_port => network_settings[:registry][:bind_port]


### PR DESCRIPTION
We don't want the glance user to be able to write the file.
