### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -136,7 +136,7 @@ keystone_register "register glance endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "glance"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{glance_protocol}://#{endpoint_public_ip}:#{api_port}"
   endpoint_adminURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"
   endpoint_internalURL "#{glance_protocol}://#{endpoint_admin_ip}:#{api_port}"

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -219,7 +219,7 @@ sqlalchemy_debug = <%= node[:glance][:debug] ? "True" : "False" %>
 # Keystone endpoint
 #auth_url = None
 # Keystone region
-#auth_region = None
+auth_region = <%= @keystone_settings['endpoint_region'] %>
 # Auth strategy
 #auth_strategy = keystone
 
@@ -363,7 +363,7 @@ swift_enable_snet = False
 
 # The region of the swift endpoint to be used for single tenant. This setting
 # is only necessary if the tenant has multiple swift endpoints.
-#swift_store_region =
+swift_store_region = <%= @keystone_settings['endpoint_region'] %>
 
 # If set to False, disables SSL layer compression of https swift requests.
 # Setting to 'False' may improve performance for images which are already
@@ -453,7 +453,7 @@ sheepdog_store_chunk_size = 64
 #cinder_endpoint_template = <None>
 
 # Region name of this node (string value)
-#os_region_name = <None>
+os_region_name = <%= @keystone_settings['endpoint_region'] %>
 
 # Location of ca certicates file to use for cinder client requests
 # (string value)

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -145,7 +145,7 @@ s3_store_create_bucket_on_put = False
 #cinder_endpoint_template = <None>
 
 # Region name of this node (string value)
-#os_region_name = <None>
+os_region_name = <%= @keystone_settings['endpoint_region'] %>
 
 # Location of ca certicates file to use for cinder client requests
 # (string value)


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
