### PR TITLE
Do not enable vmware datastore unless configured

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -94,6 +94,14 @@ end
 
 network_settings = GlanceHelper.network_settings(node)
 
+glance_stores = ["glance.store.filesystem.Store",
+                 "glance.store.http.Store",
+                 "glance.store.cinder.Store",
+                 "glance.store.rbd.Store",
+                 "glance.store.swift.Store"]
+
+glance_stores << "glance.store.vmware_datastore.Store" unless node[:glance][:vsphere][:host].empty?
+
 template node[:glance][:api][:config_file] do
   source "glance-api.conf.erb"
   owner "root"
@@ -106,7 +114,9 @@ template node[:glance][:api][:config_file] do
       :registry_bind_port => network_settings[:registry][:bind_port],
       :keystone_settings => keystone_settings,
       :rabbit_settings => fetch_rabbitmq_settings,
-      :cinder_api_insecure => cinder_api_insecure
+      :cinder_api_insecure => cinder_api_insecure,
+      :glance_stores => glance_stores.join(",")
+
   )
 end
 

--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -449,7 +449,8 @@ trace_sqlalchemy = False
 #      glance.store.cinder.Store,
 #      glance.store.gridfs.Store,
 #      glance.store.vmware_datastore.Store,
-stores = glance.store.filesystem.Store,glance.store.http.Store,glance.store.rbd.Store,glance.store.swift.Store,glance.store.cinder.Store,glance.store.vmware_datastore.Store
+stores = <%= @glance_stores %>
+
 # ============ Filesystem Store Options ========================
 
 # Directory that the Filesystem backend store


### PR DESCRIPTION
Newer versions of glance_store are checking for valid hostnames,
so better not enable it when it was not configured.