### PR TITLE
Ensure the filesystem datastore directory exists (bnc#916564)

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -102,6 +102,13 @@ glance_stores = ["glance.store.filesystem.Store",
 
 glance_stores << "glance.store.vmware_datastore.Store" unless node[:glance][:vsphere][:host].empty?
 
+directory node[:glance][:filesystem_store_datadir] do
+  owner node[:glance][:user]
+  group node[:glance][:group]
+  mode 0755
+  action :create
+end
+
 template node[:glance][:api][:config_file] do
   source "glance-api.conf.erb"
   owner "root"


### PR DESCRIPTION
In case it is modified from the default, the directory
will not exist and then glance disables the store, which
is slightly inconvenient and non-obvious.