### PR TITLE
Ensure the filesystem datastore directory exists (bnc#916564)

### DIFF
--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -85,6 +85,13 @@ end
 
 network_settings = GlanceHelper.network_settings(node)
 
+directory node[:glance][:filesystem_store_datadir] do
+  owner node[:glance][:user]
+  group node[:glance][:group]
+  mode 0755
+  action :create
+end
+
 template node[:glance][:api][:config_file] do
   source "glance-api.conf.erb"
   owner "root"


### PR DESCRIPTION
In case it is modified from the default, the directory
will not exist and then glance disables the store, which
is slightly inconvenient and non-obvious.

(cherry picked from commit fcc34870187b7057c70d07e0432e47f162e41be9)