### PR TITLE
Do not restart glance services with immediate notifications 

### DIFF
--- a/chef/cookbooks/glance/definitions/glance_service.rb
+++ b/chef/cookbooks/glance/definitions/glance_service.rb
@@ -13,7 +13,7 @@ define :glance_service do
     end
     supports :status => true, :restart => true
     action [:enable, :start]
-    subscribes :restart, resources(:template => node[:glance][short_name][:config_file]), :immediately
+    subscribes :restart, resources(:template => node[:glance][short_name][:config_file])
     provider Chef::Provider::CrowbarPacemakerService if ha_enabled
   end
 


### PR DESCRIPTION
This can hurt with chef failing later on, and when using HA, node already in maintenance mode.