### PR TITLE
HA: Set Optional ordering for Glance startup

### DIFF
--- a/chef/cookbooks/glance/recipes/ha.rb
+++ b/chef/cookbooks/glance/recipes/ha.rb
@@ -74,4 +74,11 @@ pacemaker_clone "cl-#{group_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+crowbar_pacemaker_order_only_existing "o-cl-#{group_name}" do
+  ordering [ "postgresql", "rabbitmq", "cl-keystone", "cl-#{group_name}" ]
+  score "Optional"
+  action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
 crowbar_pacemaker_sync_mark "create-glance_ha_resources"


### PR DESCRIPTION
Let Glance depend on Keystone, Database and RabbitMQ to be
started first.