### PR TITLE
Warn on file backend + HA selection

### DIFF
--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -10,7 +10,10 @@
     %fieldset
       %legend
         = t(".store_header")
-      = select_field :default_store, :collection => :default_stores_for_glance
+      = select_field :default_store, :collection => :default_stores_for_glance, "data-showit" => "file", "data-showit-target" => "#default_store_info", "data-showit-direct" => "true"
+      #default_store_info
+        .alert.alert-info{ "data-show-for-clusters-only" => "true", "data-elements-path" => "glance-server" }
+          = t('.store.file_ha_info')
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -24,6 +24,7 @@ en:
         keystone_instance: 'Keystone Instance'
         store_header: 'Image Storage'
         store:
+          file_ha_info: 'Shared storage must be used on each node of the High Availability cluster for the file store.'
           file_header: 'File Store Parameters'
           swift_header: 'Swift Store Parameters'
           rbd_header: 'RADOS Store Parameters'


### PR DESCRIPTION
A shared storage (e.g. via NFS) needs to be set up when glance is
configured as highly available. Inform user about this.

cc @vuntz @vmoravec