### PR TITLE
Set cookbook name in metadata

### DIFF
--- a/chef/cookbooks/glance/metadata.rb
+++ b/chef/cookbooks/glance/metadata.rb
@@ -1,5 +1,6 @@
-maintainer       "Dell Crowbar Team"
-maintainer_email "openstack@dell.com"
+name             "glance"
+maintainer       "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
 license          "Apache 2.0"
 description      "Installs/Configures Glance"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar framework. I.e. using
the cookbook as berkshelf dependency.
Also update maintainer email address.