### PR TITLE
Stop uploading ubuntu image

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -7,7 +7,6 @@
       "debug": false,
       "max_header_line": 16384,
       "images": [
-        "http://|ADMINWEB|/files/ami/ubuntu-12.04-server-cloudimg-amd64.tar.gz"
       ],
       "db": {
         "database": "glance",


### PR DESCRIPTION
As we are patching it away within RPM it makes sense to just drop that.
Nobody tried this predefined image anyway for ages.