### PR TITLE
Stop uploading ubuntu image

### DIFF
--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -6,7 +6,6 @@
       "verbose": true,
       "debug": false,
       "images": [
-        "http://|ADMINWEB|/files/ami/ubuntu-12.04-server-cloudimg-amd64.tar.gz"
       ],
       "db": {
         "database": "glance",


### PR DESCRIPTION
As we are patching it away within RPM it makes sense to just drop that.
Nobody tried this predefined image anyway for ages.

(cherry picked from commit f0d20bc63f4f1975c9e746d71f033c075905d8e0)