### PR TITLE
Allow pass-through of backend storage location in Glance (bsc#945043)

### DIFF
--- a/chef/cookbooks/glance/templates/default/glance-api.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-api.conf.erb
@@ -70,7 +70,7 @@ max_header_line = <%= node[:glance][:max_header_line] %>
 # file system store a URL of 'file:///path/to/image' will
 # be returned to the user in the 'direct_url' meta-data field.
 # The default value is false.
-#show_image_direct_url = False
+show_image_direct_url = <%= node[:glance][:show_storage_location] %>
 
 # Send headers containing user and tenant information when making requests to
 # the v1 glance registry. This allows the registry to function as if a user is

--- a/chef/data_bags/crowbar/bc-template-glance.json
+++ b/chef/data_bags/crowbar/bc-template-glance.json
@@ -31,6 +31,7 @@
       },
       "enable_caching": false,
       "use_cachemanagement": false,
+      "show_storage_location": false,
       "image_cache_datadir": "/var/lib/glance/image-cache",
       "image_cache_stall_timeout": 86400,
       "image_cache_max_size": 10737418240,
@@ -77,7 +78,7 @@
     "glance": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 13,
+      "schema-revision": 14,
       "element_states": {
         "glance-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-glance.schema
+++ b/chef/data_bags/crowbar/bc-template-glance.schema
@@ -54,6 +54,7 @@
             },
             "enable_caching": { "type": "bool", "required": true },
             "use_cachemanagement": { "type": "bool", "required": true },
+            "show_storage_location": { "type": "bool", "required": true },
             "image_cache_datadir": { "type": "str", "required": true },
             "image_cache_stall_timeout": { "type": "int", "required": true },
             "image_cache_max_size": { "type": "int", "required": true },

--- a/chef/data_bags/crowbar/migrate/glance/014_add_store_location.rb
+++ b/chef/data_bags/crowbar/migrate/glance/014_add_store_location.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.has_key? "show_storage_location"
+    a["show_storage_location"] = ta["show_storage_location"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.has_key? "show_storage_location"
+    a.delete("show_storage_location")
+  end
+  return a, d
+end

--- a/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/glance/_edit_attributes.html.haml
@@ -11,6 +11,7 @@
       %legend
         = t(".store_header")
       = select_field :default_store, :collection => :default_stores_for_glance, "data-showit" => "file", "data-showit-target" => "#default_store_info", "data-showit-direct" => "true"
+      = boolean_field :show_storage_location
       #default_store_info
         .alert.alert-info{ "data-show-for-clusters-only" => "true", "data-elements-path" => "glance-server" }
           = t('.store.file_ha_info')

--- a/crowbar_framework/config/locales/glance/en.yml
+++ b/crowbar_framework/config/locales/glance/en.yml
@@ -23,6 +23,7 @@ en:
         rabbitmq_instance: 'RabbitMQ'
         keystone_instance: 'Keystone Instance'
         store_header: 'Image Storage'
+        show_storage_location: 'Expose Backend Store Location'
         store:
           file_ha_info: 'Shared storage must be used on each node of the High Availability cluster for the file store.'
           file_header: 'File Store Parameters'


### PR DESCRIPTION
This can be used for various performance optimisations. There
could be a small security implication when enabling this
unconditionally, so it is an option and disabled by default.
