### PR TITLE
backport glance-scrubber fixes

### DIFF
--- a/chef/cookbooks/glance/attributes/default.rb
+++ b/chef/cookbooks/glance/attributes/default.rb
@@ -53,7 +53,13 @@ default[:glance][:image_cache_datadir] = "/var/lib/glance/image-cache/"
 
 default[:glance][:sql_idle_timeout] = "3600"
 
-#default_store choices are: file, http, https, swift, s3
+default[:glance][:glance_stores] = ["glance.store.filesystem.Store",
+                                    "glance.store.http.Store",
+                                    "glance.store.cinder.Store",
+                                    "glance.store.rbd.Store",
+                                    "glance.store.swift.Store"]
+
+#default_store choices are: file, http, https, rbd, swift, s3
 default[:glance][:default_store] = "file"
 default[:glance][:filesystem_store_datadir] = "/var/lib/glance/images"
 

--- a/chef/cookbooks/glance/recipes/api.rb
+++ b/chef/cookbooks/glance/recipes/api.rb
@@ -85,6 +85,9 @@ end
 
 network_settings = GlanceHelper.network_settings(node)
 
+glance_stores = node.default[:glance][:glance_stores]
+glance_stores += ["glance.store.vmware_datastore.Store"] unless node[:glance][:vsphere][:host].empty?
+
 directory node[:glance][:filesystem_store_datadir] do
   owner node[:glance][:user]
   group node[:glance][:group]

--- a/chef/cookbooks/glance/recipes/cache.rb
+++ b/chef/cookbooks/glance/recipes/cache.rb
@@ -28,13 +28,27 @@ end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 
+#TODO: glance should depend on cinder, but cinder already depends on glance :/
+# so we have to do something like this
+cinder_api_insecure = false
+cinders = search(:node, "roles:cinder-controller") || []
+if cinders.length > 0
+  cinder = cinders[0]
+  cinder_api_insecure = cinder[:cinder][:api][:protocol] == 'https' && cinder[:cinder][:ssl][:insecure]
+end
+
+glance_stores = node.default[:glance][:glance_stores]
+glance_stores += ["glance.store.vmware_datastore.Store"] unless node[:glance][:vsphere][:host].empty?
+
 template node[:glance][:cache][:config_file] do
   source "glance-cache.conf.erb"
   owner "root"
   group node[:glance][:group]
   mode 0640
   variables(
-      :keystone_settings => keystone_settings
+      :keystone_settings => keystone_settings,
+      :cinder_api_insecure => cinder_api_insecure,
+      :glance_stores => glance_stores.join(",")
   )
 end
 

--- a/chef/cookbooks/glance/recipes/scrubber.rb
+++ b/chef/cookbooks/glance/recipes/scrubber.rb
@@ -20,6 +20,8 @@
 
 network_settings = GlanceHelper.network_settings(node)
 
+keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+
 template node[:glance][:scrubber][:config_file] do
   source "glance-scrubber.conf.erb"
   owner "root"
@@ -27,7 +29,8 @@ template node[:glance][:scrubber][:config_file] do
   mode 0640
   variables(
     :registry_bind_host => network_settings[:registry][:bind_host],
-    :registry_bind_port => network_settings[:registry][:bind_port]
+    :registry_bind_port => network_settings[:registry][:bind_port],
+    :keystone_settings => keystone_settings
   )
 end
 

--- a/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-cache.conf.erb
@@ -47,7 +47,7 @@ registry_port = <%= @registry_bind_port %>
 #                glance.store.sheepdog.Store,
 #                glance.store.cinder.Store,
 #                glance.store.vmware_datastore.Store,
-known_stores = glance.store.filesystem.Store,glance.store.http.Store,glance.store.rbd.Store,glance.store.swift.Store,glance.store.cinder.Store,glance.store.vmware_datastore.Store
+known_stores = <%= @glance_stores %>
 
 # ============ Filesystem Store Options ========================
 

--- a/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
+++ b/chef/cookbooks/glance/templates/default/glance-scrubber.conf.erb
@@ -39,9 +39,13 @@ registry_port = <%= @registry_bind_port %>
 
 # Auth settings if using Keystone
 # auth_url = http://127.0.0.1:5000/v2.0/
+auth_url = <%= @keystone_settings['public_auth_url'] %>
 # admin_tenant_name = %SERVICE_TENANT_NAME%
+admin_tenant_name =  <%= @keystone_settings['service_tenant'] %>
 # admin_user = %SERVICE_USER%
+admin_user = <%= @keystone_settings['service_user'] %>
 # admin_password = %SERVICE_PASSWORD%
+admin_password = <%= @keystone_settings['service_password'] %>
 
 # Directory to use for lock files. Default to a temp directory
 # (string value). This setting needs to be the same for both


### PR DESCRIPTION
This is a backport of #269 
because after we merged https://github.com/SUSE-Cloud/automation/pull/866
develcloud4 testing broke in scrubber with

```
2016-02-23 04:32:37.201 25741 ERROR glance.store.filesystem [-] Specify at least 'filesystem_store_datadir' or 'filesystem_store_datadirs' option
2016-02-23 04:32:37.206 25741 ERROR glance.store.swift [-] Could not find swift_store_auth_address in configuration options.
2016-02-23 04:32:37.229 25741 ERROR glance.store.filesystem
```

not sure if this is the correct fix, though
